### PR TITLE
libqemu: build QEMU in parallel, generator-aware

### DIFF
--- a/qemu.cmake
+++ b/qemu.cmake
@@ -181,6 +181,15 @@ foreach(target ${LIBQEMU_TARGETS})
     endif()
 endforeach()
 
+# QEMU's own build parallelizes via meson/ninja. When the top-level project is
+# built with GNU Make, a literal $(MAKE) in the recipe makes Make treat this as
+# a recursive sub-make and forward its jobserver, so QEMU honours the user's -j.
+if(CMAKE_GENERATOR MATCHES "Make")
+    set(_qemu_build_command "$(MAKE)")
+else()
+    set(_qemu_build_command ${CMAKE_MAKE_PROGRAM})
+endif()
+
 ExternalProject_Add(qemu
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
     CONFIGURE_COMMAND ${CONFIGURE_ENVIRONMENT_VARIABLE} ${CMAKE_CURRENT_SOURCE_DIR}/configure
@@ -190,7 +199,7 @@ ExternalProject_Add(qemu
         --prefix=<INSTALL_DIR>
         --target-list=${target_list}
         ${QEMU_CONF_ARGS}
-    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
+    BUILD_COMMAND ${_qemu_build_command}
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
     BUILD_ALWAYS on
 )


### PR DESCRIPTION
The ExternalProject_Add(qemu ...) build step ran ${CMAKE_MAKE_PROGRAM}
with no -j flag and without connecting to the parent make's jobserver,
so QEMU built single-threaded even when the top-level build was invoked
with make -j.

For the GNU Make generator, set BUILD_COMMAND to the literal token
"$(MAKE)". GNU Make recognizes any recipe line containing the string
$(MAKE) (or ${MAKE}) as a recursive sub-make invocation and
automatically forwards the jobserver file descriptors to it, inheriting
the user's -j without hardcoding a job count. This is standard GNU
Make behavior available since very old versions.

For other generators (Ninja, etc.) the literal $(MAKE) token is
meaningless and no jobserver is forwarded. In that case BUILD_COMMAND
falls back to ${CMAKE_MAKE_PROGRAM}, invoking the build program
directly and relying on QEMU's own meson/ninja parallelism (all cores).
This is aligned to 3d01626cdf2 (qemu.cmake: use ninja by default to
build QEMU, 2026-05-08).  On Ninja < 1.13 there is no top-level
jobserver to share anyway, so this is correct and safe.

The branch uses CMAKE_GENERATOR at configure time and requires only
CMake >= 3.14, matching the project's minimum (3.16.3). This avoids
BUILD_JOB_SERVER_AWARE, which needs CMake 3.28.

Signed-off-by: Matheus Tavares Bernardino <matheus.bernardino@oss.qualcomm.com>
