### PR TITLE
target/hexagon: exec_ctr_tb not getting reset

### DIFF
--- a/target/hexagon/op_helper.c
+++ b/target/hexagon/op_helper.c
@@ -2402,8 +2402,8 @@ void HELPER(cpu_limit)(CPUHexagonState *env, target_ulong PC,
     if (ready_count > 1 &&
         env->exec_ctr_tb >= HEXAGON_TB_EXEC_PER_CPU_MAX) {
         env->gpr[HEX_REG_PC] = next_PC;
-        hexagon_raise_exception_err(env, EXCP_YIELD, next_PC);
         env->exec_ctr_tb = 0;
+        hexagon_raise_exception_err(env, EXCP_YIELD, next_PC);
     }
     env->last_cpu = env->threadId;
 }


### PR DESCRIPTION
The reset was being done after raise_exception_err and thus
was never being reset.  Possible this is part of our CI icount
runtime issues.

Change-Id: Id185afda0431f67ef2f9835a161bdd4fe144d80d
Signed-off-by: Sid Manning <sidneym@oss.qualcomm.com>
