### PR TITLE
Add ARM target for PDP Cortex-m7 bringup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,8 @@ if(NOT DEFINED LIBQEMU_TARGETS)
     set(LIBQEMU_TARGETS aarch64)
 endif()
 
-# For the arm target, use the aarch64 target which is a superset of the former.
 set(temp)
 foreach(target ${LIBQEMU_TARGETS})
-    if(target STREQUAL "arm")
-        set(target aarch64)
-    endif()
     list(APPEND temp ${target})
 endforeach()
 set(LIBQEMU_TARGETS ${temp})

--- a/libqemu/exports.py
+++ b/libqemu/exports.py
@@ -401,7 +401,7 @@ PrivateInclude('qemu/plugin.h')
 ExportPluginAPI()
 
 # ARM specific exports (32-bit and 64-bit)
-PrivateInclude('libqemu/wrappers/target/arm.h', arch = 'arm')
+PrivateInclude('libqemu/wrappers/target/arm.h', arch = 'aarch64|arm')
 ExportedFct('cpu_arm_set_imp_buildoptr', 'void', [ 'Object *', 'uint32_t' ],
         priv = 'libqemu_cpu_arm_set_imp_buildoptr', arch = 'arm')
 ExportedFct('cpu_arm_set_cpu_on_and_reset', 'int', [ 'Object *'],
@@ -410,23 +410,23 @@ ExportedFct('cpu_arm_set_cpu_off', 'int', [ 'Object *'],
         priv = 'libqemu_arm_set_cpu_off', arch = 'arm')
 # AArch64 specific exports
 ExportedFct('cpu_arm_set_cp15_cbar', 'void', [ 'Object *', 'uint64_t' ],
-        priv = 'libqemu_cpu_arm_set_cp15_cbar', arch = 'aarch64')
+        priv = 'libqemu_cpu_arm_set_cp15_cbar', arch = 'aarch64|arm')
 ExportedFct('cpu_arm_add_nvic_link', 'void', [ 'Object *' ],
-        priv = 'libqemu_cpu_arm_add_nvic_link', arch = 'aarch64')
+        priv = 'libqemu_cpu_arm_add_nvic_link', arch = 'aarch64|arm')
 ExportedFct('arm_nvic_add_cpu_link', 'void', [ 'Object *' ],
-        priv = 'libqemu_arm_nvic_add_cpu_link', arch = 'aarch64')
+        priv = 'libqemu_arm_nvic_add_cpu_link', arch = 'aarch64|arm')
 ExportedFct('cpu_aarch64_set_aarch64_mode', 'void', [ 'Object *', 'bool' ],
         priv = 'libqemu_cpu_aarch64_set_aarch64_mode', arch = 'aarch64')
 ExportedFct('cpu_arm_get_exclusive_addr', 'uint64_t', [ 'const Object *' ],
-        priv = 'libqemu_cpu_arm_get_exclusive_addr', arch = 'aarch64')
+        priv = 'libqemu_cpu_arm_get_exclusive_addr', arch = 'aarch64|arm')
 ExportedFct('cpu_arm_get_exclusive_val', 'uint64_t', [ 'const Object *' ],
-        priv = 'libqemu_cpu_arm_get_exclusive_val', arch = 'aarch64')
+        priv = 'libqemu_cpu_arm_get_exclusive_val', arch = 'aarch64|arm')
 ExportedFct('cpu_arm_set_exclusive_val', 'void', [ 'Object *', 'uint64_t' ],
-        priv = 'libqemu_cpu_arm_set_exclusive_val', arch = 'aarch64')
+        priv = 'libqemu_cpu_arm_set_exclusive_val', arch = 'aarch64|arm')
 ExportedFct('cpu_arm_post_init', 'void', [ 'Object *' ],
-        priv = 'libqemu_cpu_arm_post_init', arch = 'aarch64')
+        priv = 'libqemu_cpu_arm_post_init', arch = 'aarch64|arm')
 ExportedFct('cpu_arm_register_reset', 'void', [ 'Object *' ],
-        priv = 'libqemu_cpu_arm_register_reset', arch = 'aarch64')
+        priv = 'libqemu_cpu_arm_register_reset', arch = 'aarch64|arm')
 
 # RISC-V specific exports
 PublicInclude('libqemu/wrappers/target/riscv.h')

--- a/libqemu/wrappers/target/meson.build
+++ b/libqemu/wrappers/target/meson.build
@@ -1,6 +1,7 @@
 libqemu_ss.add(when: 'TARGET_AARCH64', if_true: files('arm.c'))
+libqemu_ss.add(when: 'TARGET_ARM', if_true: files('arm.c'))
 libqemu_ss.add(when: 'TARGET_RISCV32', if_true: files('riscv.c'))
 libqemu_ss.add(when: 'TARGET_RISCV64', if_true: files('riscv.c'))
 libqemu_ss.add(when: 'TARGET_HEXAGON', if_true: files('hexagon.c'))
 
-install_headers('riscv.h', subdir : 'libqemu/libqemu/wrappers/target')
+install_headers('arm.h', 'riscv.h', subdir : 'libqemu/libqemu/wrappers/target')

--- a/scripts/libqemu-wrappers.py
+++ b/scripts/libqemu-wrappers.py
@@ -36,7 +36,13 @@ class PrivateInclude:
     def gen():
         for i in PrivateInclude.includes:
             if i.arch:
-                gen_c('#ifdef TARGET_{}'.format(i.arch.upper()))
+                # Support multiple architectures separated by '|'
+                if '|' in i.arch:
+                    archs = [a.strip() for a in i.arch.split('|')]
+                    conditions = ' || '.join(['defined(TARGET_{})'.format(a.upper()) for a in archs])
+                    gen_c('#if {}'.format(conditions))
+                else:
+                    gen_c('#ifdef TARGET_{}'.format(i.arch.upper()))
             gen_c('#include "{}"'.format(i.path))
             if i.arch:
                 gen_c('#endif')
@@ -296,7 +302,13 @@ def gen_fill_fct():
 
     for f in ExportedFct.fcts.values():
         if f.arch:
-            gen_c('#ifdef TARGET_{}'.format(f.arch.upper()))
+            # Support multiple architectures separated by '|'
+            if '|' in f.arch:
+                archs = [a.strip() for a in f.arch.split('|')]
+                conditions = ' || '.join(['defined(TARGET_{})'.format(a.upper()) for a in archs])
+                gen_c('#if {}'.format(conditions))
+            else:
+                gen_c('#ifdef TARGET_{}'.format(f.arch.upper()))
 
         gen_c('exports->{name} = ({cast}) {target};'.format(
             name = f.pub,


### PR DESCRIPTION
Previously the "arm" entry in LIBQEMU_TARGETS was silently remapped to "aarch64" in CMakeLists.txt, so a 32-bit ARM target could never be built on its own. Remove the remap and:

- Build libqemu/wrappers/target/arm.c for TARGET_ARM in addition to TARGET_AARCH64.
- Widen the ARM-specific exports in libqemu/exports.py (cp15_cbar, NVIC link, exclusive-access, post-init, register-reset) from arch='aarch64' to arch='aarch64|arm' so they are also available under TARGET_ARM.