### PR TITLE
fix: locate VNC keymaps in build-tree LibQemu

### DIFF
--- a/system/datadir.c
+++ b/system/datadir.c
@@ -102,6 +102,18 @@ void qemu_add_default_firmwarepath(void)
 
     /* try to find datadir relative to the executable path */
     qemu_add_data_dir(get_relocated_path(CONFIG_QEMU_DATADIR));
+
+#ifdef CONFIG_LIBQEMU
+    /*
+     * LibQemu can be embedded in an executable that is not installed below
+     * QEMU's configured bindir. Keep the configured data directory as a
+     * fallback for build-tree users while retaining the relocated path as
+     * the preferred path for installed executables.
+     */
+    if (g_file_test(CONFIG_QEMU_DATADIR, G_FILE_TEST_IS_DIR)) {
+        qemu_add_data_dir(g_strdup(CONFIG_QEMU_DATADIR));
+    }
+#endif /* CONFIG_LIBQEMU */
 }
 
 void qemu_list_data_dirs(void)


### PR DESCRIPTION
VNC initialization uses QEMU's en-us keymap. For build-tree QQVP executables, relocatable data-directory lookup points outside the build tree even though the configured LibQemu data directory contains the keymap.

Keep CONFIG_QEMU_DATADIR as a fallback after the relocated path. Installed executables retain the relocated path as the preferred source, while build executables can find VNC keymaps and other QEMU data files. Restrict the fallback to CONFIG_LIBQEMU builds.