### PR TITLE
ui/sdl2: avoid unsupported external EGL handoff

### DIFF
--- a/ui/sdl2.c
+++ b/ui/sdl2.c
@@ -138,7 +138,8 @@ void sdl2_gl_create(struct sdl2_console *scon)
         scon->real_renderer = SDL_CreateRenderer(scon->real_window, -1, 0);
     }
 
-#ifdef CONFIG_OPENGL
+#if defined(CONFIG_OPENGL) && \
+    (defined(CONFIG_X11) || defined(CONFIG_GBM) || defined(WIN32))
     qemu_egl_display = eglGetCurrentDisplay();
 #endif
 


### PR DESCRIPTION
On macOS, SDL creates the OpenGL context used by the Qbox display bridge, but the Homebrew virglrenderer build does not provide its Epoxy EGL backend. Unconditionally assigning eglGetCurrentDisplay() therefore makes LibQemu advertise an external EGL display to virglrenderer. Virglrenderer then enters its external-EGL initialization path and fails with:

    EGL is not supported on this platform
    virgl could not be initialized: -1

Only expose QEMU's current EGL display on platforms where the corresponding external EGL path is supported and configured: X11, GBM, and Windows. On macOS, leave the handoff unset so virglrenderer uses QEMU's normal SDL GL context callbacks instead of the unavailable external-EGL backend.

This preserves the working macOS SDL/virgl path while keeping the EGL handoff available for platforms that use it.